### PR TITLE
Update DicomXML.cs

### DIFF
--- a/FO-DICOM.Core/Serialization/DicomXML.cs
+++ b/FO-DICOM.Core/Serialization/DicomXML.cs
@@ -75,11 +75,29 @@ namespace FellowOakDicom.Serialization
                     WriteDicomAttribute(xmlOutput, sq);
                     for (var i = 0; i < sq.Items.Count; i++)
                     {
-                        xmlOutput.AppendLine($@"<Item number=""{i+1}"">");
+                        xmlOutput.AppendLine($@"<Item number=""{i + 1}"">");
 
                         DicomDatasetToXml(xmlOutput, sq.Items[i]);
 
                         xmlOutput.AppendLine(@"</Item>");
+                    }
+                    xmlOutput.AppendLine(@"</DicomAttribute>");
+                }
+                else if (item is DicomFragmentSequence)
+                {
+                    var sq = item as DicomFragmentSequence;
+
+                    WriteDicomAttribute(xmlOutput, sq);
+                   
+                    for (var i = 0; i < sq.Fragments.Count; i++)
+                    {
+                        xmlOutput.AppendLine($@"<Fragment number=""{i + 1}"">");
+                        if (sq.Fragments[i].Data?.Length > 0)
+                        {
+                            var binaryString = GetBinaryBase64(sq.Fragments[i].Data);
+                            xmlOutput.AppendLine($@"<InlineBinary>{binaryString}</InlineBinary>");
+                        }
+                        xmlOutput.AppendLine(@"</Fragment>");
                     }
                     xmlOutput.AppendLine(@"</DicomAttribute>");
                 }
@@ -151,6 +169,12 @@ namespace FellowOakDicom.Serialization
             IByteBuffer buffer = item.Buffer;
             if (buffer == null) return string.Empty;
             return Convert.ToBase64String(buffer.Data);
+        }
+
+        private static string GetBinaryBase64(byte[] buffer)
+        {
+            if (buffer == null) return string.Empty;
+            return Convert.ToBase64String(buffer);
         }
 
         private static string EscapeXml(string text)


### PR DESCRIPTION
I am trying to put tother an app to convert DICOM datasets to XML, and I noticed that when a dataset contains elements of type DicomFragmentSequence, such as "Pixel Data," they are not being generated in the output XML. After looking into the the problem, I took the initiative to address this issue. I have made modifications to the code to handle DicomFragmentSequence elements  include their fragments in the XML output. I have done initial testing, and the modified code seems to work as expected.

Fixes # .

#### Checklist
- [ ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-Change made in DicomXML class in DicomDatasetToXml function to handle DicomFragmentSequence
-
-
